### PR TITLE
Fix serverPath conflict with index files, fix paths output into build

### DIFF
--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -3,7 +3,6 @@
 const Path = require('path');
 const Util = require('util');
 const Fs = require('fs');
-const Bounce = require('@hapi/bounce');
 const Hoek = require('@hapi/hoek');
 const Somever = require('@hapi/somever');
 const Rimraf = require('rimraf');
@@ -50,11 +49,7 @@ exports.Plugin = class {
 
     async initialize() {
 
-        const { servicePath } = this.sls.config;
-
-        const rootOrPath = Path.resolve(servicePath, Hoek.reach(this.sls, 'service.custom.lalalambda.serverPath') || '');
-
-        const server = this.server = await internals.getServer(rootOrPath);
+        const server = this.server = await internals.getServer(this.serverPath);
 
         Hoek.assert(server.plugins.lalalambda, 'Lalalambda needs to be registered as a plugin on your hapi server.');
     }
@@ -103,17 +98,34 @@ exports.Plugin = class {
         Hoek.assert(server, 'Lalalambda must be initialized.');
 
         const { servicePath } = this.sls.config;
-        const { lambdas } = server.plugins.lalalambda;
+        const buildFolderPath = Path.join(servicePath, BUILD_FOLDER);
 
         await this.cleanup();
-        await internals.mkdir(Path.join(servicePath, BUILD_FOLDER));
+        await internals.mkdir(buildFolderPath);
+
+        const { lambdas } = server.plugins.lalalambda;
 
         for (const id of lambdas.keys()) {
             await internals.writeFile(
-                Path.join(servicePath, BUILD_FOLDER, `${id}.js`),
-                internals.entrypoint(id, Hoek.reach(this.sls, 'service.custom.lalalambda.serverPath'))
+                Path.join(buildFolderPath, `${id}.js`),
+                // Path listed in entrypoint should be relative
+                // in order for the code to remain portable.
+                internals.entrypoint(id, Path.relative(buildFolderPath, this.serverPath))
             );
         }
+    }
+
+    get serverPath() {
+
+        const { servicePath } = this.sls.config;
+
+        const serverPath = Hoek.reach(
+            this.sls,
+            ['service', 'custom', 'lalalambda', 'serverPath'],
+            { default: 'server' }
+        );
+
+        return Path.resolve(servicePath, serverPath);
     }
 };
 
@@ -154,16 +166,7 @@ internals.writeFile = Util.promisify(Fs.writeFile);
 
 internals.rimraf = Util.promisify(Rimraf);
 
-internals.getServer = async (rootOrPath) => {
-
-    let path = Path.join(rootOrPath, 'server');
-
-    try {
-        path = require.resolve(rootOrPath);
-    }
-    catch (err) {
-        Bounce.rethrow(err, 'system');
-    }
+internals.getServer = async (path) => {
 
     try {
 
@@ -186,10 +189,13 @@ internals.getServer = async (rootOrPath) => {
 };
 
 // eslint-disable-next-line @hapi/hapi/scope-start
-internals.entrypoint = (id, serverPath = '') => `'use strict';
+internals.entrypoint = (id, path) => `'use strict';
 
 const Path = require('path');
 const Lalalambda = require('lalalambda');
 
-exports.handler = Lalalambda.handler('${id}', Path.resolve(__dirname, '..', '${serverPath}'));
+exports.handler = Lalalambda.handler('${internals.esc(id)}', Path.resolve(__dirname, '${internals.esc(path)}'));
 `;
+
+// Allow slashes and single-quotes in filenames
+internals.esc = (str) => str.replace(/(\\|')/g, '\\$1');

--- a/test/closet/invoke-custom-server-path-escaped/'.js
+++ b/test/closet/invoke-custom-server-path-escaped/'.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const { Hapi } = require('../../helpers');
+const Lalalambda = require('../../..');
+
+exports.deployment = async () => {
+
+    const server = Hapi.server();
+
+    await server.register(Lalalambda);
+
+    server.lambda({
+        id: 'invoke-lambda',
+        handler: () => ({ success: 'invoked' })
+    });
+
+    return server;
+};

--- a/test/closet/invoke-custom-server-path-escaped/.serverless_plugins/lalalambda.js
+++ b/test/closet/invoke-custom-server-path-escaped/.serverless_plugins/lalalambda.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('../../../..');

--- a/test/closet/invoke-custom-server-path-escaped/serverless.yaml
+++ b/test/closet/invoke-custom-server-path-escaped/serverless.yaml
@@ -1,0 +1,12 @@
+service: my-service
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+
+custom:
+  lalalambda:
+    serverPath: "'.js"
+
+plugins:
+  - lalalambda

--- a/test/closet/invoke/index.js
+++ b/test/closet/invoke/index.js
@@ -1,0 +1,2 @@
+// This exists to ensure that when serverPath isn't specified, this file
+// doesn't get picked-up as the default server export rather than server.js

--- a/test/index.js
+++ b/test/index.js
@@ -1313,9 +1313,20 @@ describe('Lalalambda', () => {
             expect(output).to.contain(`"success": "invoked"`);
         });
 
-        it('can locally invoke a lambda registered by hapi to a custom serverpath.', async () => {
+        it('can locally invoke a lambda registered by hapi to a custom serverPath.', async () => {
 
             const serverless = Helpers.makeServerless('invoke-custom-server-path', ['invoke', 'local', '--function', 'invoke-lambda']);
+
+            await serverless.init();
+
+            const output = await serverless.run();
+
+            expect(output).to.contain(`"success": "invoked"`);
+        });
+
+        it('can locally invoke a lambda registered by hapi to a custom serverPath containing a single quote.', async () => {
+
+            const serverless = Helpers.makeServerless('invoke-custom-server-path-escaped', ['invoke', 'local', '--function', 'invoke-lambda']);
 
             await serverless.init();
 
@@ -1434,7 +1445,7 @@ describe('Lalalambda', () => {
                 const Path = require('path');
                 const Lalalambda = require('lalalambda');
 
-                exports.handler = Lalalambda.handler('package-lambda', Path.resolve(__dirname, '..', ''));
+                exports.handler = Lalalambda.handler('package-lambda', Path.resolve(__dirname, '../server'));
             `));
 
             const cfFile = await readFile(Path.join(__dirname, 'closet', 'package', '.serverless', 'cloudformation-template-update-stack.json'));


### PR DESCRIPTION
I started leaving some final comments on https://github.com/hapipal/lalalambda/pull/9, but they were esoteric enough that I thought it would be best to just ping-pong some code back your way!  I was experiencing one bug: index files in the root of the project were competing with the default server path due to the way `getServer()` fell back to `require.resolve(path)`.  It always resolved successfully when there was no server path but there was an index file at the root.  I fixed this by applying the default `serverPath` of `'server'` eagerly rather than trying to fall back to it at the last moment.

I also did cleanup on some related code.  Now we escape some characters that could reasonably show-up in file paths when writing them into a string literal in `entrypoint()`.  And I try to make super sure to pass a relative file path to `entrypoint`, since absolute files wont make sense in the build.  As you pointed out, an absolute `serverPath` is already a bad idea, but I figured it couldn't hurt to tighten that up.

If you like these feel free to merge then we can go back over to https://github.com/hapipal/lalalambda/pull/9, but if you'd like to approach any of this differently I'd be open to that as well!